### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/01-1-Set-up-environment.md
+++ b/Instructions/Labs/01-1-Set-up-environment.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 0: Set up environment'
+  title: 'Lab 0: Set up environment'
+  description: This appendix contains step-by-step instructions to provision and configure a Dynamics 365 Customer Insights environment, including prerequisites.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Dynamics 365
 ---
 
 # Lab 0: Set up environment

--- a/Instructions/Labs/01-1-Set-up-environment.md
+++ b/Instructions/Labs/01-1-Set-up-environment.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 0: Set up environment'
   description: This appendix contains step-by-step instructions to provision and configure a Dynamics 365 Customer Insights environment, including prerequisites.
-  duration: 30 minutes
+  duration: 10 minutes
   level: 200
   islab: true
   primarytopics:

--- a/Instructions/Labs/02-1-Ingest-a-dataset.md
+++ b/Instructions/Labs/02-1-Ingest-a-dataset.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 2.1: Ingest a dataset'
+  title: 'Lab 2.1: Ingest a dataset'
+  description: As Project Manager for Contoso Retail, you will create a unified customer profile by ingesting key sources of customer data and following the Map, Match, and Merge process. In this lab, we will ingest data. In the next lab, we will unify the data.
+  duration: 130 minutes
+  level: 300
+  islab: true
 ---
 
 # Module 2: Ingest data into Dynamics 365 Customer Insights - Data

--- a/Instructions/Labs/02-1-Ingest-a-dataset.md
+++ b/Instructions/Labs/02-1-Ingest-a-dataset.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 2.1: Ingest a dataset'
   description: As Project Manager for Contoso Retail, you will create a unified customer profile by ingesting key sources of customer data and following the Map, Match, and Merge process. In this lab, we will ingest data. In the next lab, we will unify the data.
-  duration: 130 minutes
+  duration: 45 minutes
   level: 300
   islab: true
 ---

--- a/Instructions/Labs/02-2-Create-unified-profile.md
+++ b/Instructions/Labs/02-2-Create-unified-profile.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 2.2: Create a unified customer profile'
+  title: 'Lab 2.2: Create a unified customer profile'
+  description: Having ingested the raw data from your data sources into entities, you will now begin the Map, Match, Merge process to create a single Unified Customer Profile by merging data from each customer profile source. To do this, you will first map your ingested entities against a standard model and select the Primary Key for each of your profiled entities. Following the completion of this, you will then create your Match Rule that will be used to match contacts from all customer entities. Finally, running the Merge process will create a single set of unique Customers having matched profiles from all customer entities using your match rules. Your objective is to find out how many unique customer profiles Contoso Retail has across various data sources.
+  duration: 118 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 2.2: Create a unified customer profile

--- a/Instructions/Labs/02-2-Create-unified-profile.md
+++ b/Instructions/Labs/02-2-Create-unified-profile.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 2.2: Create a unified customer profile'
   description: Having ingested the raw data from your data sources into entities, you will now begin the Map, Match, Merge process to create a single Unified Customer Profile by merging data from each customer profile source. To do this, you will first map your ingested entities against a standard model and select the Primary Key for each of your profiled entities. Following the completion of this, you will then create your Match Rule that will be used to match contacts from all customer entities. Finally, running the Merge process will create a single set of unique Customers having matched profiles from all customer entities using your match rules. Your objective is to find out how many unique customer profiles Contoso Retail has across various data sources.
-  duration: 118 minutes
+  duration: 30 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/03-1-Upload assets.md
+++ b/Instructions/Labs/03-1-Upload assets.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 3.1: Upload assets'
+  title: 'Lab 3.1: Upload assets'
+  description: To get started, the Marketing Coordinator needs to upload the digital assets that will be used in the campaign. They also need to upload any new sales contacts the company has acquired recently and update details for existing contacts and accounts.
+  duration: 90 minutes
+  level: 100
+  islab: true
 ---
 
 # Module 3: Manage customers and assets in Dynamics 365 Customer Insights - Journeys

--- a/Instructions/Labs/03-1-Upload assets.md
+++ b/Instructions/Labs/03-1-Upload assets.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 3.1: Upload assets'
   description: To get started, the Marketing Coordinator needs to upload the digital assets that will be used in the campaign. They also need to upload any new sales contacts the company has acquired recently and update details for existing contacts and accounts.
-  duration: 90 minutes
+  duration: 15 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/03-2-Create-email.md
+++ b/Instructions/Labs/03-2-Create-email.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 3.2: Create an email'
   description: This lab will take approximately 45 minutes to complete.
-  duration: 158 minutes
+  duration: 45 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/03-2-Create-email.md
+++ b/Instructions/Labs/03-2-Create-email.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 3.2: Create an email'
+  title: 'Lab 3.2: Create an email'
+  description: This lab will take approximately 45 minutes to complete.
+  duration: 158 minutes
+  level: 100
+  islab: true
 ---
 
 # Learning Path 3: Manage customers and assets in Dynamics 365 Customer Insights - Journeys

--- a/Instructions/Labs/04-1-Journey.md
+++ b/Instructions/Labs/04-1-Journey.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 4.1: Create a trigger-based journey'
+  title: 'Lab 4.1: Create a trigger-based journey'
+  description: Now that we have created our 3 emails, it is time to create a journey to send the emails to our customers. We will send our first email to our customers to let them know about the upcoming Airpot Smart Machine Coffee Maker.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Learning Path 4: Create journeys


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/01-1-Set-up-environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/02-1-Ingest-a-dataset.md` (description,duration,level,islab)
- `Instructions/Labs/02-2-Create-unified-profile.md` (description,duration,level,islab)
- `Instructions/Labs/03-1-Upload assets.md` (description,duration,level,islab)
- `Instructions/Labs/03-2-Create-email.md` (description,duration,level,islab)
- `Instructions/Labs/04-1-Journey.md` (description,duration,level,islab)
